### PR TITLE
Change assertRaises in MultiWindowTest to expect Type- instead of Runtim...

### DIFF
--- a/src/test/MultiWindowTest.py
+++ b/src/test/MultiWindowTest.py
@@ -42,7 +42,7 @@ class MultiWindowTestCase(AVGTestCase):
         app.CUSTOM_SETTINGS = {}
         app.settings.set('app_windowconfig', 'avgwindowconfig.xml')
         app.settings.set('app_window_size', '160x120')
-        self.assertRaises(RuntimeError, lambda: app.testRun([]))
+        self.assertRaises(TypeError, lambda: app.testRun([]))
         libavg.app.instance = None
 
         app = AppTest.TestApp()


### PR DESCRIPTION
...eError.

Matches Error thrown in app.py on invalid config settings. [fixes #528]
