### PR TITLE
Fix memleak in bmp.getPixels(True) [fixes #562]

### DIFF
--- a/src/wrapper/bitmap_wrap.cpp
+++ b/src/wrapper/bitmap_wrap.cpp
@@ -86,9 +86,12 @@ static bp::object Bitmap_getPixels(Bitmap& bitmap, bool bCopyData=true)
     unsigned char* pBuffer = bitmap.getPixels();
     int buffSize = bitmap.getMemNeeded();
     if (bCopyData) {
-        char * pBufCopy = new char[buffSize];
-        memcpy(pBufCopy, pBuffer, buffSize);
-        return bp::object(handle<>(PyBuffer_FromMemory(pBufCopy, buffSize)));
+        bp::object pyBuffer(handle<>(PyBuffer_New(buffSize)));
+        void* pTargetBuffer;
+        Py_ssize_t pyBuffSize  = buffSize;
+        PyObject_AsWriteBuffer(pyBuffer.ptr(), &pTargetBuffer, &pyBuffSize);
+        memcpy(pTargetBuffer, pBuffer, buffSize);
+        return pyBuffer;
     } else {
 #if PY_MAJOR_VERSION < 3
         return bp::object(handle<>(PyBuffer_FromMemory(pBuffer, buffSize)));


### PR DESCRIPTION
It should be fixed, afaik the reason is that `pBufCopy` would not be deallocated automatically as 
"[The caller is responsible for the data ptr](https://docs.python.org/2.7/c-api/buffer.html?highlight=pybuffer_new#c.PyBuffer_FromMemory)" when using `PyBuffer_FromMemory`, when the PythonObject is destroyed.

[`PyBuffer_New` maintains its own memory](https://docs.python.org/2.7/c-api/buffer.html?highlight=pybuffer_new#c.PyBuffer_New) so it should automatically deallocate the memory.
(It works for the sample program given in #562 )
