### PR TITLE
Add buildbot badges from nightlies to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [Libavg](https://www.libavg.de)
 ======
-Windows: [![Build Status](http://www.libavg.de:8010/png?builder=i386-win-full)](http://www.libavg.de:8010/builders/i386-win-full)
-Linux: [![Build Status](http://www.libavg.de:8010/png?builder=x64-lnx-full)](http://www.libavg.de:8010/builders/x64-lnx-full)
-OSX: [![Build Status](http://www.libavg.de:8010/png?builder=x64-osx-full)](http://www.libavg.de:8010/builders/x64-osx-full)
+Windows: [![Build Status](http://libavg.de:8010/png?builder=i386-win-full)](http://www.libavg.de:8010/builders/i386-win-full)
+Linux: [![Build Status](http://libavg.de:8010/png?builder=x64-lnx-full)](http://www.libavg.de:8010/builders/x64-lnx-full)
+OSX: [![Build Status](http://libavg.de:8010/png?builder=x64-osx-full)](http://www.libavg.de:8010/builders/x64-osx-full)
 
 [Libavg](https://www.libavg.de) is a high-level development platform for media-centric applications. It allows programmers, media artists and designers to quickly develop media applications, uses python as scripting language and is written in high-speed C++.
 


### PR DESCRIPTION
Adds buildbot badges from latest master nightly to readme, and linkifies first two occurances of libavg in text

Badges look just like this. (There are prettier ones, but those are buildbot defaults…)
Windows: [![Build Status](http://libavg.de:8010/png?builder=i386-win-full)](http://libavg.de:8010/builders/i386-win-full)
Linux: [![Build Status](http://libavg.de:8010/png?builder=x64-lnx-full)](http://libavg.de:8010/builders/x64-lnx-full)
OSX: [![Build Status](http://libavg.de:8010/png?builder=x64-osx-full)](http://libavg.de:8010/builders/x64-osx-full)
