### PR TITLE
Fixed first == last detection in VectorNode::getNumDifferentPts().

### DIFF
--- a/src/player/VectorNode.cpp
+++ b/src/player/VectorNode.cpp
@@ -499,6 +499,13 @@ void VectorNode::calcBevelTC(const WideLine& line1, const WideLine& line2,
 int VectorNode::getNumDifferentPts(const vector<glm::vec2>& pts)
 {
     int numPts = pts.size();
+
+    if (numPts < 2) {
+        return numPts;
+    }
+    if (glm::distance2(pts[0], pts[numPts-1])<0.1) {
+        numPts--;
+    }
     for (unsigned i=1; i<pts.size(); ++i) {
         if (glm::distance2(pts[i], pts[i-1])<0.1) {
             numPts--;

--- a/src/test/VectorTest.py
+++ b/src/test/VectorTest.py
@@ -351,7 +351,13 @@ class VectorTestCase(AVGTestCase):
             polyline2.linejoin="bevel"
             polyline2.pos = [(50,10), (60,10), (50,11)]
             canvas.removeChild(1)
-        
+
+        def createSamePts():
+            avg.PolyLineNode(pos=((10,20), (10,20), (10,20)), parent=canvas)
+            avg.PolyLineNode(pos=((10,20), (10,20), (20,30)), parent=canvas)
+            avg.PolyLineNode(pos=((20,30), (10,20), (10,20)), parent=canvas)
+            avg.PolyLineNode(pos=((10,20), (20,30), (10,20)), parent=canvas)
+
         canvas = self.makeEmptyCanvas()
         polyline = addPolyLine()
         self.start(False,
@@ -367,7 +373,8 @@ class VectorTestCase(AVGTestCase):
                  testAlmostEmptyPolyLine,
                  lambda: self.compareImage("testPolyLine5"),
                  testAcutePolyLine,
-                 lambda: self.compareImage("testPolyLine6")
+                 lambda: self.compareImage("testPolyLine6"),
+                 createSamePts
                 ))
 
     def testTexturedPolyLine(self):
@@ -473,6 +480,12 @@ class VectorTestCase(AVGTestCase):
                 dell = canvas.getChild(i)
                 canvas.removeChild(dell)
 
+        def createSamePts():
+            avg.PolygonNode(pos=((10,20), (10,20), (10,20)), parent=canvas)
+            avg.PolygonNode(pos=((10,20), (10,20), (20,30)), parent=canvas)
+            avg.PolygonNode(pos=((20,30), (10,20), (10,20)), parent=canvas)
+            avg.PolygonNode(pos=((10,20), (20,30), (10,20)), parent=canvas)
+
         self.__mouseDownCalled = False
         canvas = self.makeEmptyCanvas()
         polygon = addPolygon()
@@ -503,7 +516,8 @@ class VectorTestCase(AVGTestCase):
                  createOneHole,
                  lambda: self.compareImage("testPolygonHole1"),
                  createMoreHoles,
-                 lambda: self.compareImage("testPolygonHole2")
+                 lambda: self.compareImage("testPolygonHole2"),
+                 createSamePts
                 ))
 
     def testTexturedPolygon(self):


### PR DESCRIPTION
First point (coordinates) equal to last point in PolygonNode and PolyLineNode not checked properly.