### PR TITLE
[WIP] Features/cpp11

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,7 @@ AC_SUBST(OBJCLDFLAGS)
 _AM_DEPENDENCIES([OBJC])
 LDFLAGS="$LDFLAGS -rdynamic"
 if [[ $target_vendor = apple ]]; then
- CXXFLAGS="$CXXFLAGS -Wno-c++11-extensions"
+ CXXFLAGS="$CXXFLAGS -std=c++11"
 else
  CXXFLAGS="$CXXFLAGS -std=c++0x"
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,11 @@ AC_SUBST(OBJCFLAGS)
 AC_SUBST(OBJCLDFLAGS)
 _AM_DEPENDENCIES([OBJC])
 LDFLAGS="$LDFLAGS -rdynamic"
+if [[ $target_vendor = apple ]]; then
+ CXXFLAGS="$CXXFLAGS -Wno-c++11-extensions"
+else
+ CXXFLAGS="$CXXFLAGS -std=c++0x"
+fi
 
 if [[ $target_vendor = apple ]] && [[ x"`which port`" = x"/opt/local/bin/port" ]]; then
     AC_MSG_RESULT([Macports detected. Adding include and lib search paths])


### PR DESCRIPTION
Tested under Windows (MSVC 2010), recent Linux (Ubuntu 14.04) and recent Mac (XCode 5.1, LLVM 3.4svn). In theory, should work with any gcc version >= 4.2 as well.
However, this breaks on our Mac Build server. According to https://en.wikipedia.org/Wiki/Xcode, anything >= 4.2 (needs Lion) uses CLANG and thus should work.
Leaving this for now - I believe noone wants to update the Mac Build Server.