### PR TITLE
Check if m_pDisplayEngine is not null before calling teardown

### DIFF
--- a/src/player/Player.cpp
+++ b/src/player/Player.cpp
@@ -1164,7 +1164,9 @@ void Player::initGraphics()
 
     if (m_bDisplayEngineBroken) {
         m_bDisplayEngineBroken = false;
-        m_pDisplayEngine->teardown();
+        if (m_pDisplayEngine) {
+            m_pDisplayEngine->teardown();
+        }
         m_pDisplayEngine = DisplayEnginePtr();
     }
 


### PR DESCRIPTION
If player.play has been terminated by an uncaught exception, a successive call to player.play results in an null pointer exception. The reason for this is, if player.keepWindowOpen is not set, the display engine will be set to null, which is not considered by the following cleanup code.

See Player.cpp:511, 1688, 1167

```python
#!/usr/bin/env python

from libavg import avg, player

def throwException():
    raise RuntimeError()

def run(action):
    player.subscribe(player.ON_FRAME, action)
    player.play()


player.createMainCanvas(size=(160, 120))
#player.keepWindowOpen()

try:
    run(throwException)
except RuntimeError as e:
    print 'RuntimeError caught'

# Crashes here if keepWindowOpen is not set
player.createMainCanvas(size=(160, 120))
player.play()
# press ESC to exit
```

