### PR TITLE
passing on sPublisherName explicitely through all subClasses of Node

### DIFF
--- a/src/player/AVGNode.cpp
+++ b/src/player/AVGNode.cpp
@@ -41,8 +41,8 @@ void AVGNode::registerType()
     TypeRegistry::get()->registerType(def);
 }
 
-AVGNode::AVGNode(const ArgList& args)
-    : CanvasNode(args)
+AVGNode::AVGNode(const ArgList& args, const std::string& sPublisherName)
+    : CanvasNode(args, sPublisherName)
 {
     args.setMembers(this);
 }

--- a/src/player/AVGNode.h
+++ b/src/player/AVGNode.h
@@ -34,7 +34,7 @@ class AVG_API AVGNode : public CanvasNode
     public:
         static void registerType();
         
-        AVGNode(const ArgList& args);
+        AVGNode(const ArgList& args, const std::string& sPublisherName = "Node");
         virtual ~AVGNode();
 };
 

--- a/src/player/AreaNode.cpp
+++ b/src/player/AreaNode.cpp
@@ -67,8 +67,9 @@ void AreaNode::registerType()
     TypeRegistry::get()->registerType(def);
 }
 
-AreaNode::AreaNode()
-    : m_RelViewport(0,0,0,0),
+AreaNode::AreaNode(const std::string& sPublisherName)
+    : Node(sPublisherName),
+      m_RelViewport(0,0,0,0),
       m_bTransformChanged(true)
 {
     ObjectCounter::get()->incRef(&typeid(*this));

--- a/src/player/AreaNode.h
+++ b/src/player/AreaNode.h
@@ -102,7 +102,7 @@ class AVG_API AreaNode: public Node
             { return IntPoint(0,0); };
 
     protected:
-        AreaNode();
+        AreaNode(const std::string& sPublisherName="Node");
         glm::vec2 getUserSize() const;
         Pixel32 getEffectiveOutlineColor(Pixel32 parentColor) const;
 

--- a/src/player/CameraNode.cpp
+++ b/src/player/CameraNode.cpp
@@ -74,8 +74,9 @@ void CameraNode::registerType()
     TypeRegistry::get()->registerType(def);
 }
 
-CameraNode::CameraNode(const ArgList& args)
-    : m_bIsPlaying(false),
+CameraNode::CameraNode(const ArgList& args, const std::string& sPublisherName)
+    : RasterNode(sPublisherName),
+      m_bIsPlaying(false),
       m_FrameNum(0),
       m_bAutoUpdateCameraImage(true),
       m_bNewBmp(false),

--- a/src/player/CameraNode.h
+++ b/src/player/CameraNode.h
@@ -48,7 +48,7 @@ class AVG_API CameraNode : public RasterNode
     public:
         static void registerType();
         
-        CameraNode(const ArgList& args);
+        CameraNode(const ArgList& args, const std::string& sPublisherName = "Node");
         virtual ~CameraNode();
 
         virtual void connectDisplay();

--- a/src/player/CanvasNode.cpp
+++ b/src/player/CanvasNode.cpp
@@ -39,7 +39,7 @@ void CanvasNode::registerType()
     TypeRegistry::get()->registerType(def);
 }
 
-CanvasNode::CanvasNode(const ArgList& args)
+CanvasNode::CanvasNode(const ArgList& args, const std::string& sPublisherName)
     : DivNode(args)
 {
     args.setMembers(this);

--- a/src/player/CanvasNode.h
+++ b/src/player/CanvasNode.h
@@ -32,7 +32,7 @@ class AVG_API CanvasNode : public DivNode
     public:
         static void registerType();
         
-        CanvasNode(const ArgList& args);
+        CanvasNode(const ArgList& args, const std::string& sPublisherName = "Node");
         virtual ~CanvasNode();
 
         virtual std::string getEffectiveMediaDir();

--- a/src/player/DivNode.cpp
+++ b/src/player/DivNode.cpp
@@ -59,7 +59,7 @@ void DivNode::registerType()
     TypeRegistry::get()->registerType(def);
 }
 
-DivNode::DivNode(const ArgList& args)
+DivNode::DivNode(const ArgList& args, const std::string& sPublisherName) : AreaNode(sPublisherName)
 {
     args.setMembers(this);
     ObjectCounter::get()->incRef(&typeid(*this));

--- a/src/player/DivNode.h
+++ b/src/player/DivNode.h
@@ -40,7 +40,7 @@ class AVG_API DivNode : public AreaNode
     public:
         static void registerType();
         
-        DivNode(const ArgList& args);
+        DivNode(const ArgList& args, const std::string& sPublisherName = "Node");
         virtual ~DivNode();
         virtual void connectDisplay();
         virtual void connect(CanvasPtr pCanvas);

--- a/src/player/ImageNode.cpp
+++ b/src/player/ImageNode.cpp
@@ -56,8 +56,8 @@ void ImageNode::registerType()
     TypeRegistry::get()->registerType(def);
 }
 
-ImageNode::ImageNode(const ArgList& args)
-    : m_Compression(TEXCOMPRESSION_NONE)
+ImageNode::ImageNode(const ArgList& args, const std::string& sPublisherName)
+    : RasterNode(sPublisherName), m_Compression(TEXCOMPRESSION_NONE)
 {
     args.setMembers(this);
     m_pGPUImage = GPUImagePtr(new GPUImage(getSurface(), getMipmap()));

--- a/src/player/ImageNode.h
+++ b/src/player/ImageNode.h
@@ -41,7 +41,7 @@ class AVG_API ImageNode : public RasterNode
     public:
         static void registerType();
         
-        ImageNode(const ArgList& args);
+        ImageNode(const ArgList& args, const std::string& sPublisherName = "Node");
         virtual ~ImageNode();
         virtual void connectDisplay();
         virtual void connect(CanvasPtr pCanvas);

--- a/src/player/OffscreenCanvasNode.cpp
+++ b/src/player/OffscreenCanvasNode.cpp
@@ -46,8 +46,8 @@ void OffscreenCanvasNode::registerType()
     TypeRegistry::get()->registerType(def);
 }
 
-OffscreenCanvasNode::OffscreenCanvasNode(const ArgList& args)
-    : CanvasNode(args)
+OffscreenCanvasNode::OffscreenCanvasNode(const ArgList& args, const std::string& sPublisherName)
+    : CanvasNode(args, sPublisherName)
 {
     args.setMembers(this);
 }

--- a/src/player/OffscreenCanvasNode.h
+++ b/src/player/OffscreenCanvasNode.h
@@ -32,7 +32,7 @@ class AVG_API OffscreenCanvasNode : public CanvasNode
     public:
         static void registerType();
         
-        OffscreenCanvasNode(const ArgList& args);
+        OffscreenCanvasNode(const ArgList& args, const std::string& sPublisherName = "Node");
         virtual ~OffscreenCanvasNode();
 
         bool getHandleEvents() const;

--- a/src/player/PublisherDefinition.cpp
+++ b/src/player/PublisherDefinition.cpp
@@ -1,5 +1,5 @@
 //
-//  libavg - Media Playback Engine. 
+//  libavg - Media Playback Engine.
 //  Copyright (C) 2003-2014 Ulrich von Zadow
 //
 //  This library is free software; you can redistribute it and/or
@@ -33,7 +33,7 @@ PublisherDefinition::PublisherDefinition(const string& sName, const string& sBas
     : m_sName(sName)
 {
     if (sBaseName != "") {
-        PublisherDefinitionPtr pBaseDef = 
+        PublisherDefinitionPtr pBaseDef =
                 PublisherDefinitionRegistry::get()->getDefinition(sBaseName);
         m_MessageIDs = pBaseDef->m_MessageIDs;
     }
@@ -43,8 +43,8 @@ PublisherDefinition::~PublisherDefinition()
 {
 }
 
-PublisherDefinitionPtr PublisherDefinition::create(const std::string& sName, 
-            const std::string& sBaseName)
+PublisherDefinitionPtr PublisherDefinition::create( const std::string& sName,
+                                                    const std::string& sBaseName)
 {
     PublisherDefinitionPtr pDef(new PublisherDefinition(sName, sBaseName));
     PublisherDefinitionRegistry::get()->registerDefinition(pDef);
@@ -78,7 +78,7 @@ const std::string& PublisherDefinition::getName() const
 {
     return m_sName;
 }
-    
+
 void PublisherDefinition::dump() const
 {
     cerr << m_sName << endl;

--- a/src/player/RasterNode.cpp
+++ b/src/player/RasterNode.cpp
@@ -73,8 +73,9 @@ void RasterNode::registerType()
     TypeRegistry::get()->registerType(def);
 }
 
-RasterNode::RasterNode()
-    : m_pSurface(0),
+RasterNode::RasterNode(const std::string& sPublisherName)
+    : AreaNode(sPublisherName),
+      m_pSurface(0),
       m_bMipmap(false),
       m_Color(0,0,0,0),
       m_TileSize(-1,-1),

--- a/src/player/RasterNode.h
+++ b/src/player/RasterNode.h
@@ -102,7 +102,7 @@ class AVG_API RasterNode: public AreaNode
         void resetFXDirty();
 
     protected:
-        RasterNode();
+        RasterNode(const std::string& sPublisherName = "Node");
         
         void scheduleFXRender();
         void calcVertexArray(const VertexArrayPtr& pVA);

--- a/src/player/VideoNode.cpp
+++ b/src/player/VideoNode.cpp
@@ -74,8 +74,9 @@ void VideoNode::registerType()
     TypeRegistry::get()->registerType(def);
 }
 
-VideoNode::VideoNode(const ArgList& args)
-    : m_VideoState(Unloaded),
+VideoNode::VideoNode(const ArgList& args,const std::string& sPublisherName)
+    : RasterNode(sPublisherName),
+      m_VideoState(Unloaded),
       m_bFrameAvailable(false),
       m_bFirstFrameDecoded(false),
       m_Filename(""),

--- a/src/player/VideoNode.h
+++ b/src/player/VideoNode.h
@@ -50,7 +50,7 @@ class AVG_API VideoNode: public RasterNode, IFrameEndListener
 
         static void registerType();
         
-        VideoNode(const ArgList& args);
+        VideoNode(const ArgList& args, const std::string& sPublisherName = "Node");
         virtual ~VideoNode();
         
         virtual void connectDisplay();

--- a/src/player/WordsNode.cpp
+++ b/src/player/WordsNode.cpp
@@ -112,8 +112,9 @@ void WordsNode::registerType()
     TypeRegistry::get()->registerType(def);
 }
 
-WordsNode::WordsNode(const ArgList& args)
-    : m_LogicalSize(0,0),
+WordsNode::WordsNode(const ArgList& args, const std::string& sPublisherName)
+    : RasterNode(sPublisherName),
+      m_LogicalSize(0,0),
       m_pFontDescription(0),
       m_pLayout(0),
       m_bRenderNeeded(true)

--- a/src/player/WordsNode.h
+++ b/src/player/WordsNode.h
@@ -39,7 +39,7 @@ class AVG_API WordsNode : public RasterNode
     public:
         static void registerType();
         
-        WordsNode(const ArgList& args);
+        WordsNode(const ArgList& args, const std::string& sPublisherName = "Node");
         virtual ~WordsNode();
         
         virtual void connectDisplay();


### PR DESCRIPTION
This allows to use `addMessage()` and `notifySubscribers()`to invoke notifications in derived classes, such as plugins.