### PR TITLE
Add -Wno-unused-local-typedef compiler option.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,6 +29,8 @@ AC_PROG_CXX
 AC_PROG_CC
 AC_PROG_CPP
 CXXFLAGS="-O3 -ffast-math -Wall -pipe -Wno-invalid-offsetof -Woverloaded-virtual -Wswitch -Wuninitialized -Wempty-body $CXXFLAGS"
+# Silence boost warnings with gcc 4.8
+CXXFLAGS="$CXXFLAGS -Wno-unknown-warning-option -Wno-unused-local-typedef"
 CFLAGS="-O3 -ffast-math -Wall -pipe $CFLAGS"
 if [[ $host_cpu == i386 ]] || [[ $host_cpu == i686 ]] || [[ $host_cpu == x86_64 ]]; then
     CXXFLAGS="-msse2 $CXXFLAGS"


### PR DESCRIPTION
Fixes GCC 4.8 warning in boost headers.