### PR TITLE
AreaNode: Check if the size value has changed before emitting a SIZE_…

### DIFF
--- a/src/player/AreaNode.cpp
+++ b/src/player/AreaNode.cpp
@@ -105,7 +105,9 @@ void AreaNode::connectDisplay()
         m_RelViewport.setHeight(float(m_UserSize.y));
     }
     if (m_UserSize.x == 0.0 || m_UserSize.y == 0) {
-        notifySubscribers("SIZE_CHANGED", m_RelViewport.size());
+        if (m_UserSize != m_RelViewport.size()) {
+            notifySubscribers("SIZE_CHANGED", m_RelViewport.size());
+        }
     }
     m_bTransformChanged = true;
     Node::connectDisplay();

--- a/src/player/AreaNode.cpp
+++ b/src/player/AreaNode.cpp
@@ -104,10 +104,10 @@ void AreaNode::connectDisplay()
     } else {
         m_RelViewport.setHeight(float(m_UserSize.y));
     }
-    if (m_UserSize.x == 0.0 || m_UserSize.y == 0) {
-        if (m_UserSize != m_RelViewport.size()) {
-            notifySubscribers("SIZE_CHANGED", m_RelViewport.size());
-        }
+    if ((m_UserSize.x == 0.0 || m_UserSize.y == 0.0) &&
+            m_UserSize != m_RelViewport.size())
+    {
+        notifySubscribers("SIZE_CHANGED", m_RelViewport.size());
     }
     m_bTransformChanged = true;
     Node::connectDisplay();

--- a/src/test/EventTest.py
+++ b/src/test/EventTest.py
@@ -177,12 +177,12 @@ class EventTestCase(AVGTestCase):
                  lambda: imgHandlerTester.assertState((avg.Node.CURSOR_UP,))
                 ))
 
-    def testRasterNodeAutoResizeFromMediaSize(self):
+    def testAreaNodeDeriveSizeFromMediaSize(self):
         root = self.loadEmptyScene()
 
         # If an AreaNode is constructed without a size argument, the node size
-        # is inferred from the underlying media. If the size cannot be
-        # inferred, the default size (0, 0) is kept and not SIZE_CHANGED
+        # is derived from the underlying media. If the size cannot be
+        # derived, the default size (0, 0) is kept and no SIZE_CHANGED
         # signal is emitted.
         div = avg.DivNode(parent=root)
         image = avg.ImageNode(parent=root, href="rgb24-65x65.png")
@@ -213,9 +213,9 @@ class EventTestCase(AVGTestCase):
         video.subscribe(video.SIZE_CHANGED, onVideoSizeChanged)
 
         self.start(False,
-                   (lambda: self.assert_( self.divSizeReceived == avg.Point2D(-1, -1)),
+                   (lambda: self.assert_(self.divSizeReceived == avg.Point2D(-1, -1)),
                     lambda: self.assert_(self.imageSizeReceived == avg.Point2D(65, 65)),
-                    lambda: self.assert_( self.imageNoMediaSizeReceived == avg.Point2D(-1, -1)),
+                    lambda: self.assert_(self.imageNoMediaSizeReceived == avg.Point2D(-1, -1)),
                     lambda: self.assert_(self.videoSizeReceived == avg.Point2D(48, 48))
                    ))
 
@@ -1150,7 +1150,7 @@ def eventTestSuite(tests):
             "testTilted",
             "testWordsClicks",
             "testDivEvents",
-            "testRasterNodeAutoResizeFromMediaSize",
+            "testAreaNodeDeriveSizeFromMediaSize",
             "testDivNegativePos",
             "testUnlinkInHandler",
             "testConnectHandler",

--- a/src/test/EventTest.py
+++ b/src/test/EventTest.py
@@ -177,6 +177,48 @@ class EventTestCase(AVGTestCase):
                  lambda: imgHandlerTester.assertState((avg.Node.CURSOR_UP,))
                 ))
 
+    def testRasterNodeAutoResizeFromMediaSize(self):
+        root = self.loadEmptyScene()
+
+        # If an AreaNode is constructed without a size argument, the node size
+        # is inferred from the underlying media. If the size cannot be
+        # inferred, the default size (0, 0) is kept and not SIZE_CHANGED
+        # signal is emitted.
+        div = avg.DivNode(parent=root)
+        image = avg.ImageNode(parent=root, href="rgb24-65x65.png")
+        imageNoMedia = avg.ImageNode(parent=root)
+        video = avg.VideoNode(parent=root, href="rgba-48x48.mov")
+        video.pause()
+
+        self.divSizeReceived = avg.Point2D(-1, -1)
+        self.imageSizeReceived = avg.Point2D(-1, -1)
+        self.imageNoMediaSizeReceived = avg.Point2D(-1, -1)
+        self.videoSizeReceived = avg.Point2D(-1, -1)
+
+        def onDivSizeChanged(size):
+            self.divSizeReceived = size
+
+        def onImageSizeChanged(size):
+            self.imageSizeReceived = size
+
+        def onImageNoMediaSizeChanged(size):
+            self.imageNoMediaSizeReceived = size
+
+        def onVideoSizeChanged(size):
+            self.videoSizeReceived = size
+
+        div.subscribe(div.SIZE_CHANGED, onDivSizeChanged)
+        image.subscribe(image.SIZE_CHANGED, onImageSizeChanged)
+        imageNoMedia.subscribe(imageNoMedia.SIZE_CHANGED, onImageNoMediaSizeChanged)
+        video.subscribe(video.SIZE_CHANGED, onVideoSizeChanged)
+
+        self.start(False,
+                   (lambda: self.assert_( self.divSizeReceived == avg.Point2D(-1, -1)),
+                    lambda: self.assert_(self.imageSizeReceived == avg.Point2D(65, 65)),
+                    lambda: self.assert_( self.imageNoMediaSizeReceived == avg.Point2D(-1, -1)),
+                    lambda: self.assert_(self.videoSizeReceived == avg.Point2D(48, 48))
+                   ))
+
     def testDivNegativePos(self):
         root = self.loadEmptyScene()
         div = avg.DivNode(pos=(10,10), parent=root)
@@ -1108,6 +1150,7 @@ def eventTestSuite(tests):
             "testTilted",
             "testWordsClicks",
             "testDivEvents",
+            "testRasterNodeAutoResizeFromMediaSize",
             "testDivNegativePos",
             "testUnlinkInHandler",
             "testConnectHandler",


### PR DESCRIPTION
I noticed that AreaNode::connectDisplay emits an SIZE_CHANGED signal if the default size (0, 0) is used during initialization (see AreaNode.cpp:108)

The side effect is, that a DivNode which listens to SIZE_CHANGED in order to
adjust the sizes of its children receives a zero immediately after startup. Consequently, nothing is shown on screen.

```python
#!/usr/bin/env python
# -*- coding: utf-8 -*-

from libavg import avg, player
player.createMainCanvas(size=(640, 480))

class Div(avg.DivNode):
    def __init__(self, node, parent=None, **kwargs):
        super(Div, self).__init__(**kwargs)
        self.registerInstance(self, parent)

        self.node = node
        self.appendChild(self.node)
        self.subscribe(self.SIZE_CHANGED, self.onSizeChange)

    def onSizeChange(self, size):
        print 'size {} received'.format(size)
        self.node.size = size

def demo():
    rect = avg.RectNode(fillopacity=1, size=(100, 100))
    # Use default size
    div = Div(parent=player.getRootNode(), node=rect)

# Works around the issue
# player.setTimeout(0, demo)
demo()

player.play()
```

To change this behaviour, AreaNode::connctDisplay could emit the signal only if the value of the size would change.
