### PR TITLE
fix: setting slider pos initially

### DIFF
--- a/src/python/widget/slider.py
+++ b/src/python/widget/slider.py
@@ -179,6 +179,7 @@ class SliderBase(avg.DivNode):
 
         self._range = range
         self._thumbPos = thumbPos
+        self.setThumbPos(thumbPos)
 
         self.subscribe(self.SIZE_CHANGED, lambda newSize: self._positionNodes())
         if orientation == Orientation.HORIZONTAL:


### PR DESCRIPTION
Initializing a slider with a certain value did not automatically set the slider's thumb to the corresponding position. Now it does.