### PR TITLE
Fix avg scripts staging

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -24,8 +24,8 @@ copyDirIfDifferent(python-build PRE_BUILD
 copyPythonToStaging("libavg/data")
 copyPythonToStaging("libavg/app")
 copyPythonToStaging("libavg/widget")
-copyPythonToStaging("libavg/scripts")
 copyPythonToStaging("libavg")
+copyPythonToStaging("scripts")
 add_custom_command(TARGET python-build
         COMMAND ${PYTHON_INTERPRETER} setup.py build)
 


### PR DESCRIPTION
The avg scripts were not staged and installed due a path issue in python/CMakeLists.txt