### PR TITLE
Make FontStyle and WordsNode accept unicode strings

### DIFF
--- a/src/player/FontStyle.cpp
+++ b/src/player/FontStyle.cpp
@@ -36,16 +36,16 @@ void FontStyle::registerType()
 {
     TypeDefinition def = TypeDefinition("fontstyle", "",
             ExportedObject::buildObject<FontStyle>)
-        .addArg(Arg<string>("font", "sans", false, offsetof(FontStyle, m_sName)))
-        .addArg(Arg<string>("variant", "", false, offsetof(FontStyle, m_sVariant)))
+        .addArg(Arg<UTF8String>("font", "sans", false, offsetof(FontStyle, m_sName)))
+        .addArg(Arg<UTF8String>("variant", "", false, offsetof(FontStyle, m_sVariant)))
         .addArg(Arg<Color>("color", Color("FFFFFF"), false,
                 offsetof(FontStyle, m_Color)))
         .addArg(Arg<float>("aagamma", 1.0f, false, offsetof(FontStyle, m_AAGamma)))
         .addArg(Arg<float>("fontsize", 15, false, offsetof(FontStyle, m_Size)))
         .addArg(Arg<int>("indent", 0, false, offsetof(FontStyle, m_Indent)))
         .addArg(Arg<float>("linespacing", 0, false, offsetof(FontStyle, m_LineSpacing)))
-        .addArg(Arg<string>("alignment", "left"))
-        .addArg(Arg<string>("wrapmode", "word"))
+        .addArg(Arg<UTF8String>("alignment", "left"))
+        .addArg(Arg<UTF8String>("wrapmode", "word"))
         .addArg(Arg<bool>("justify", false, false, offsetof(FontStyle, m_bJustify)))
         .addArg(Arg<float>("letterspacing", 0, false,
                 offsetof(FontStyle, m_LetterSpacing)))
@@ -58,8 +58,8 @@ void FontStyle::registerType()
 FontStyle::FontStyle(const ArgList& args)
 {
     args.setMembers(this);
-    setAlignment(args.getArgVal<string>("alignment"));
-    setWrapMode(args.getArgVal<string>("wrapmode"));
+    setAlignment(args.getArgVal<UTF8String>("alignment"));
+    setWrapMode(args.getArgVal<UTF8String>("wrapmode"));
     if (args.getArgVal<FontStylePtr>("basestyle") != 0) {
         applyBaseStyle(*(args.getArgVal<FontStylePtr>("basestyle")), args);
     }
@@ -69,8 +69,8 @@ FontStyle::FontStyle()
 {
     const ArgList& args = TypeRegistry::get()->getTypeDef("fontstyle").getDefaultArgs();
     args.setMembers(this);
-    setAlignment(args.getArgVal<string>("alignment"));
-    setWrapMode(args.getArgVal<string>("wrapmode"));
+    setAlignment(args.getArgVal<UTF8String>("alignment"));
+    setWrapMode(args.getArgVal<UTF8String>("wrapmode"));
 }
 
 FontStyle::~FontStyle()
@@ -122,7 +122,7 @@ void FontStyle::setDefaultedArgs(const ArgList& args)
     setDefaultedArg(m_Size, "fontsize", args);
     setDefaultedArg(m_Indent, "indent", args);
     setDefaultedArg(m_LineSpacing, "linespacing", args);
-    string s = getAlignment();
+    UTF8String s = getAlignment();
     setDefaultedArg(s, "alignment", args);
     setAlignment(s);
     s = getWrapMode();
@@ -133,22 +133,22 @@ void FontStyle::setDefaultedArgs(const ArgList& args)
     setDefaultedArg(m_bHint, "hint", args);
 }
 
-const std::string& FontStyle::getFont() const
+const UTF8String& FontStyle::getFont() const
 {
     return m_sName;
 }
 
-void FontStyle::setFont(const string& sName)
+void FontStyle::setFont(const UTF8String& sName)
 {
     m_sName = sName;
 }
 
-const std::string& FontStyle::getFontVariant() const
+const UTF8String& FontStyle::getFontVariant() const
 {
     return m_sVariant;
 }
 
-void FontStyle::setFontVariant(const std::string& sVariant)
+void FontStyle::setFontVariant(const UTF8String& sVariant)
 {
     m_sVariant = sVariant;
 }
@@ -206,7 +206,7 @@ void FontStyle::setLineSpacing(float lineSpacing)
     m_LineSpacing = lineSpacing;
 }
 
-string FontStyle::getAlignment() const
+UTF8String FontStyle::getAlignment() const
 {
     switch(m_Alignment) {
         case PANGO_ALIGN_LEFT:
@@ -221,7 +221,7 @@ string FontStyle::getAlignment() const
     }
 }
 
-void FontStyle::setAlignment(const string& sAlign)
+void FontStyle::setAlignment(const UTF8String& sAlign)
 {
     if (sAlign == "left") {
         m_Alignment = PANGO_ALIGN_LEFT;
@@ -235,7 +235,7 @@ void FontStyle::setAlignment(const string& sAlign)
     }
 }
 
-void FontStyle::setWrapMode(const string& sWrapMode)
+void FontStyle::setWrapMode(const UTF8String& sWrapMode)
 {
     if (sWrapMode == "word") {
         m_WrapMode = PANGO_WRAP_WORD;
@@ -249,7 +249,7 @@ void FontStyle::setWrapMode(const string& sWrapMode)
     }
 }
 
-string FontStyle::getWrapMode() const
+UTF8String FontStyle::getWrapMode() const
 {
     switch(m_WrapMode) {
         case PANGO_WRAP_WORD:

--- a/src/player/FontStyle.h
+++ b/src/player/FontStyle.h
@@ -28,6 +28,8 @@
 
 #include "../graphics/Color.h"
 
+#include "../base/UTF8String.h"
+
 #include <pango/pango.h>
 #include <boost/shared_ptr.hpp>
 
@@ -49,11 +51,11 @@ class AVG_API FontStyle: public ExportedObject
 
         void setDefaultedArgs(const ArgList& args);
 
-        const std::string& getFont() const;
-        void setFont(const std::string& sName);
+        const UTF8String& getFont() const;
+        void setFont(const UTF8String& sName);
 
-        const std::string& getFontVariant() const;
-        void setFontVariant(const std::string& sVariant);
+        const UTF8String& getFontVariant() const;
+        void setFontVariant(const UTF8String& sVariant);
         
         const Color& getColor() const;
         void setColor(const Color& color);
@@ -70,11 +72,11 @@ class AVG_API FontStyle: public ExportedObject
         float getLineSpacing() const;
         void setLineSpacing(float lineSpacing);
         
-        std::string getAlignment() const;
-        void setAlignment(const std::string& sAlignment);
+        UTF8String getAlignment() const;
+        void setAlignment(const UTF8String& sAlignment);
  
-        std::string getWrapMode() const;
-        void setWrapMode(const std::string& sWrapMode);
+        UTF8String getWrapMode() const;
+        void setWrapMode(const UTF8String& sWrapMode);
 
         bool getJustify() const;
         void setJustify(bool bJustify);
@@ -91,8 +93,8 @@ class AVG_API FontStyle: public ExportedObject
     private:
         void applyBaseStyle(const FontStyle& baseStyle, const ArgList& args);
 
-        std::string m_sName;
-        std::string m_sVariant;
+        UTF8String m_sName;
+        UTF8String m_sVariant;
         Color m_Color;
         float m_AAGamma;
         float m_Size;

--- a/src/player/WordsNode.cpp
+++ b/src/player/WordsNode.cpp
@@ -92,16 +92,16 @@ void WordsNode::registerType()
             ExportedObject::buildObject<WordsNode>)
         .addChildren(sChildren)
         .addDTDElements(sDTDElements)
-        .addArg(Arg<string>("font", "sans"))
-        .addArg(Arg<string>("variant", ""))
+        .addArg(Arg<UTF8String>("font", "sans"))
+        .addArg(Arg<UTF8String>("variant", ""))
         .addArg(Arg<UTF8String>("text", ""))
         .addArg(Arg<Color>("color", Color("FFFFFF")))
         .addArg(Arg<float>("aagamma", 1.0f))
         .addArg(Arg<float>("fontsize", 15))
         .addArg(Arg<int>("indent", 0, false))
         .addArg(Arg<float>("linespacing", 0))
-        .addArg(Arg<string>("alignment", "left"))
-        .addArg(Arg<string>("wrapmode", "word"))
+        .addArg(Arg<UTF8String>("alignment", "left"))
+        .addArg(Arg<UTF8String>("wrapmode", "word"))
         .addArg(Arg<bool>("justify", false))
         .addArg(Arg<bool>("rawtextmode", false, false, 
                 offsetof(WordsNode, m_bRawTextMode)))
@@ -178,12 +178,12 @@ void WordsNode::disconnect(bool bKill)
     RasterNode::disconnect(bKill);
 }
 
-string WordsNode::getAlignment() const
+UTF8String WordsNode::getAlignment() const
 {
     return m_FontStyle.getAlignment();
 }
 
-void WordsNode::setAlignment(const string& sAlign)
+void WordsNode::setAlignment(const UTF8String& sAlign)
 {
     m_FontStyle.setAlignment(sAlign);
     updateLayout();
@@ -264,18 +264,18 @@ void WordsNode::setFontStyle(const FontStyle& fontStyle)
     updateFont();
 }
 
-const std::string& WordsNode::getFont() const
+const UTF8String& WordsNode::getFont() const
 {
     return m_FontStyle.getFont();
 }
 
-void WordsNode::setFont(const std::string& sName)
+void WordsNode::setFont(const UTF8String& sName)
 {
     m_FontStyle.setFont(sName);
     updateFont();
 }
 
-const std::string& WordsNode::getFontVariant() const
+const UTF8String& WordsNode::getFontVariant() const
 {
     return m_FontStyle.getFontVariant();
 }
@@ -286,7 +286,7 @@ void WordsNode::addFontDir(const std::string& sDir)
     TextEngine::get(false).addFontDir(sDir);
 }
 
-void WordsNode::setFontVariant(const std::string& sVariant)
+void WordsNode::setFontVariant(const UTF8String& sVariant)
 {
     m_FontStyle.setFontVariant(sVariant);
     updateFont();
@@ -458,13 +458,13 @@ glm::vec2 WordsNode::getLineExtents(int line)
     return glm::vec2(float(logical_rect.width), float(logical_rect.height));
 }
 
-void WordsNode::setWrapMode(const string& sWrapMode)
+void WordsNode::setWrapMode(const UTF8String& sWrapMode)
 {
     m_FontStyle.setWrapMode(sWrapMode);
     updateLayout();
 }
 
-string WordsNode::getWrapMode() const
+UTF8String WordsNode::getWrapMode() const
 {
     return m_FontStyle.getWrapMode();
 }

--- a/src/player/WordsNode.h
+++ b/src/player/WordsNode.h
@@ -61,11 +61,11 @@ class AVG_API WordsNode : public RasterNode
         const FontStyle& getFontStyle() const;
         void setFontStyle(const FontStyle& fontStyle);
 
-        const std::string& getFont() const;
-        void setFont(const std::string& sName);
+        const UTF8String& getFont() const;
+        void setFont(const UTF8String& sName);
 
-        const std::string& getFontVariant() const;
-        void setFontVariant(const std::string& sVariant);
+        const UTF8String& getFontVariant() const;
+        void setFontVariant(const UTF8String& sVariant);
 
         const UTF8String& getText() const; 
         void setText(const UTF8String& sText);
@@ -88,11 +88,11 @@ class AVG_API WordsNode : public RasterNode
         bool getRawTextMode() const;
         void setRawTextMode(bool rawTextMode);
         
-        std::string getAlignment() const;
-        void setAlignment(const std::string& sAlignment);
+        UTF8String getAlignment() const;
+        void setAlignment(const UTF8String& sAlignment);
  
-        std::string getWrapMode() const;
-        void setWrapMode(const std::string& sWrapMode);
+        UTF8String getWrapMode() const;
+        void setWrapMode(const UTF8String& sWrapMode);
 
         bool getJustify() const;
         void setJustify(bool bJustify);

--- a/src/test/WordsTest.py
+++ b/src/test/WordsTest.py
@@ -100,6 +100,25 @@ class WordsTestCase(AVGTestCase):
                  lambda: self.compareImage("testFontStyle2"),
                 ))
 
+    def testUnicodeAttributes(self):
+
+        try:
+            fontStyle = avg.FontStyle(font=u"Bitstream Vera Sans", variant=u"Roman",
+                    alignment=u"left", wrapmode=u"word")
+            self.assert_(fontStyle.font == "Bitstream Vera Sans")
+            avg.WordsNode(fontstyle=fontStyle, text="Bitstream Vera Sans")
+
+        except avg.Exception as e:
+            msg = "Failed to create FontStyle object by using unicode strings as parameters"
+            self.fail(msg)
+
+        try:
+            avg.WordsNode(font=u"Bitstream Vera Sans", variant=u"Roman",
+                    text=u"Bold", alignment=u"left", wrapmode=u"word")
+        except avg.Exception:
+            msg = "Failed to create WordsNode object by using unicode strings as parameters"
+            self.fail(msg)
+
     def testBaseStyle(self):
         attrs = {"font": "Bitstream Vera Sans",
                  "variant": "Bold",
@@ -654,6 +673,7 @@ def wordsTestSuite(tests):
             "testSimpleWords",
             "testRedrawOnDemand",
             "testFontStyle",
+            "testUnicodeAttributes",
             "testBaseStyle",
             "testGlyphPos",
             "testParaWords",


### PR DESCRIPTION
We just replaced std::string type with UTF8String, in FontStyle and in WordsNode classes. The following tests did not work before the changes and work afterwards. We also tested each parameter alone, with and without "u" before the strings, repeating the same tests before and after the changes.


```python
from libavg import avg, app

LOREM = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore " \
        "magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo " \
        "consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. " \
        "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."


class MainDiv(app.MainDiv):

    def onInit(self):

        font = avg.FontStyle(font=u"sans", variant=u"bold", fontsize=30, alignment=u"left",  wrapmode=u"word")

        avg.WordsNode(text=LOREM, fontstyle=font, pos=(0, 0), size=(400, 400), parent=self)

        avg.WordsNode(text=LOREM, font=u"sans", variant=u"bold", alignment=u"left",  wrapmode=u"word",
                      fontsize=30, pos=(500, 0), size=(400, 400), parent=self)


app.App().run(MainDiv(), app_resolution="1200x700")

```

```python
#For this test we copied the folder: "libavg/python/libavg/data" inside the file folder

from libavg import avg, app, widget


class MainDiv(app.MainDiv):

    def onInit(self):
        skin = widget.Skin("SimpleSkin.xml", mediaDir="data")
        skin.fonts["downFont"].variant = u"bold"

app.App().run(MainDiv(), app_resolution="1200x700")

```

