### PR TITLE
Add support for FFmpeg 4.0

### DIFF
--- a/src/avgconfig.h.cmake.in
+++ b/src/avgconfig.h.cmake.in
@@ -6,3 +6,5 @@
 #cmakedefine AVG_ENABLE_V4L2
 #cmakedefine AVG_ENABLE_1394_2
 #cmakedefine AVG_ENABLE_CMU1394
+
+#cmakedefine FFMPEG_AVRESAMPLE_FOUND

--- a/src/player/VideoWriterThread.cpp
+++ b/src/player/VideoWriterThread.cpp
@@ -198,7 +198,7 @@ void VideoWriterThread::setupVideoStream()
     pCodecContext->qmax = m_QMax;
     // some formats want stream headers to be separate
     if (m_pOutputFormatContext->oformat->flags & AVFMT_GLOBALHEADER) {
-        pCodecContext->flags |= CODEC_FLAG_GLOBAL_HEADER;
+        pCodecContext->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
     }
     m_FramesWritten = 0;
 }

--- a/src/video/AudioDecoderThread.cpp
+++ b/src/video/AudioDecoderThread.cpp
@@ -166,7 +166,7 @@ void AudioDecoderThread::decodePacket(AVPacket* pPacket)
             bIsPlanar = av_sample_fmt_is_planar((AVSampleFormat)m_InputSampleFormat);
             if (bIsPlanar) {
                 char* pPackedData = (char*)av_malloc(AVCODEC_MAX_AUDIO_FRAME_SIZE +
-                        FF_INPUT_BUFFER_PADDING_SIZE);
+                        AV_INPUT_BUFFER_PADDING_SIZE);
                 planarToInterleaved(pPackedData, pDecodedFrame, m_pStream->codec->channels,
                         framesDecoded);
                 pBuffer = resampleAudio(pPackedData, framesDecoded,

--- a/src/video/AudioDecoderThread.cpp
+++ b/src/video/AudioDecoderThread.cpp
@@ -62,7 +62,7 @@ AudioDecoderThread::AudioDecoderThread(CQueue& cmdQ, AudioMsgQueue& msgQ,
 AudioDecoderThread::~AudioDecoderThread()
 {
     if (m_pResampleContext) {
-#ifdef LIBAVRESAMPLE_VERSION
+#ifdef FFMPEG_AVRESAMPLE_FOUND
         avresample_close(m_pResampleContext);
         avresample_free(&m_pResampleContext);
 #else
@@ -236,7 +236,7 @@ AudioBufferPtr AudioDecoderThread::resampleAudio(char* pDecodedData, int framesD
         int currentSampleFormat)
 {
     if (!m_pResampleContext) {
-#ifdef LIBAVRESAMPLE_VERSION
+#ifdef FFMPEG_AVRESAMPLE_FOUND
         m_pResampleContext = avresample_alloc_context();
         av_opt_set_int(m_pResampleContext, "in_channel_layout",
                 av_get_default_channel_layout(m_pStream->codec->channels), 0);
@@ -255,7 +255,7 @@ AudioBufferPtr AudioDecoderThread::resampleAudio(char* pDecodedData, int framesD
 #endif
         AVG_ASSERT(m_pResampleContext);
     }
-#ifdef LIBAVRESAMPLE_VERSION
+#ifdef FFMPEG_AVRESAMPLE_FOUND
     uint8_t *pResampledData;
     int leftoverSamples = avresample_available(m_pResampleContext);
     int framesAvailable = leftoverSamples +

--- a/src/video/AudioDecoderThread.h
+++ b/src/video/AudioDecoderThread.h
@@ -68,7 +68,7 @@ class AVG_API AudioDecoderThread : public WorkerThread<AudioDecoderThread> {
 
         int m_InputSampleRate;
         int m_InputSampleFormat;
-#ifdef LIBAVRESAMPLE_VERSION
+#ifdef FFMPEG_AVRESAMPLE_FOUND
         AVAudioResampleContext * m_pResampleContext;
 #else
         ReSampleContext * m_pResampleContext;

--- a/src/video/WrapFFMpeg.h
+++ b/src/video/WrapFFMpeg.h
@@ -99,6 +99,14 @@ extern "C" {
     #define AV_PIX_FMT_YUYV422 PIX_FMT_YUYV422
 #endif
 
+// Defines renamed in libav 12 / FFmpeg 2.8
+#ifndef AV_INPUT_BUFFER_PADDING_SIZE
+  #define AV_INPUT_BUFFER_PADDING_SIZE FF_INPUT_BUFFER_PADDING_SIZE
+#endif
+#ifndef AV_CODEC_FLAG_GLOBAL_HEADER
+  #define AV_CODEC_FLAG_GLOBAL_HEADER CODEC_FLAG_GLOBAL_HEADER
+#endif
+
 namespace avg
 {
     const std::string getAVErrorString(int errNum);

--- a/src/video/WrapFFMpeg.h
+++ b/src/video/WrapFFMpeg.h
@@ -66,7 +66,7 @@ extern "C" {
         #define url_fclose avio_close
         #define URL_WRONLY AVIO_FLAG_WRITE
 #endif
-#ifdef HAVE_LIBAVRESAMPLE_AVRESAMPLE_H
+#ifdef FFMPEG_AVRESAMPLE_FOUND
     #include <libavresample/avresample.h>
     #include <libavresample/version.h>
 #endif


### PR DESCRIPTION
These are a few fixes needed to get libavg to build with FFmpeg 4.0. The first commit fixes the detection of libavresample which wasn't being used. This is needed because FFmpeg 4.0 dropped the old resampling API. The second commit renames some constants after the old versions were dropped in FFmpeg.