### PR TITLE
Resolve "cerr" error

### DIFF
--- a/src/base/ThreadHelper.cpp
+++ b/src/base/ThreadHelper.cpp
@@ -19,6 +19,7 @@
 //  Current versions can be found at www.libavg.de
 //
 
+#include <iostream>
 #include "ThreadHelper.h"
 #include "Exception.h"
 #include "OSHelper.h"


### PR DESCRIPTION
I encounter this error when installing in a Ubuntu 18.04 machine:

>[  3%] Built target tess
[  3%] Built target copy_python_tests
[  3%] Building CXX object src/base/CMakeFiles/base.dir/ThreadHelper.cpp.o
/home/tunghim/libavg/src/base/ThreadHelper.cpp: In function ‘void avg::printAffinityMask(cpu_set_t&)’:
/home/tunghim/libavg/src/base/ThreadHelper.cpp:39:9: error: ‘cerr’ was not declared in this scope
         cerr << int(CPU_ISSET(i, &mask));
         ^~~~
/home/tunghim/libavg/src/base/ThreadHelper.cpp:39:9: note: suggested alternative: ‘erf’
         cerr << int(CPU_ISSET(i, &mask));
         ^~~~
         erf
/home/tunghim/libavg/src/base/ThreadHelper.cpp:41:5: error: ‘cerr’ was not declared in this scope
     cerr << endl;
     ^~~~
/home/tunghim/libavg/src/base/ThreadHelper.cpp:41:5: note: suggested alternative: ‘erf’
     cerr << endl;
     ^~~~
     erf
src/base/CMakeFiles/base.dir/build.make:758: recipe for target 'src/base/CMakeFiles/base.dir/ThreadHelper.cpp.o' failed
make[2]: *** [src/base/CMakeFiles/base.dir/ThreadHelper.cpp.o] Error 1
CMakeFiles/Makefile2:414: recipe for target 'src/base/CMakeFiles/base.dir/all' failed
make[1]: *** [src/base/CMakeFiles/base.dir/all] Error 2
Makefile:140: recipe for target 'all' failed
make: *** [all] Error 2

I added `#include <iostream>` to src/base/ThreadHelper.cpp, and the problem is fixed. This may sound trivial, but it happened. Happy coding!