### PR TITLE
Remove unused sphinx.ext.pngmath extension

### DIFF
--- a/sphinxdoc/conf.py
+++ b/sphinxdoc/conf.py
@@ -25,7 +25,7 @@ import sys
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.pngmath', 'sphinx.ext.coverage',
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.coverage',
         'sphinx.ext.graphviz', 'sphinx.ext.inheritance_diagram']
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
This extension has been deprecated in Sphinx 1.4 and removed in Sphinx 1.8, see sphinx-doc/sphinx#4702.

It is unused in this repository, as there are no math [directives][1] or [roles][2].

[1]: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#math
[2]: https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#math